### PR TITLE
Support protobuf serialization/deserialization for dynamic filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,6 +2427,7 @@ dependencies = [
  "ahash 0.8.12",
  "arrow",
  "criterion",
+ "dashmap",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
@@ -2443,6 +2444,7 @@ dependencies = [
  "petgraph 0.8.3",
  "rand 0.9.2",
  "rstest",
+ "uuid",
 ]
 
 [[package]]
@@ -2560,6 +2562,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/datafusion/core/benches/sort.rs
+++ b/datafusion/core/benches/sort.rs
@@ -200,7 +200,12 @@ impl BenchCase {
         let sort = make_sort_exprs(schema.as_ref());
 
         let source = MemorySourceConfig::try_new_exec(partitions, schema, None).unwrap();
-        let exec = SortExec::new(sort.clone(), source).with_preserve_partitioning(true);
+        let exec = SortExec::new(
+            sort.clone(),
+            source,
+            task_ctx.session_config().get_extension(),
+        )
+        .with_preserve_partitioning(true);
         let plan = Arc::new(SortPreservingMergeExec::new(sort, Arc::new(exec)));
 
         Self {
@@ -222,7 +227,11 @@ impl BenchCase {
 
         let exec = MemorySourceConfig::try_new_exec(partitions, schema, None).unwrap();
         let exec = Arc::new(CoalescePartitionsExec::new(exec));
-        let plan = Arc::new(SortExec::new(sort, exec));
+        let plan = Arc::new(SortExec::new(
+            sort,
+            exec,
+            task_ctx.session_config().get_extension(),
+        ));
 
         Self {
             runtime,
@@ -242,7 +251,8 @@ impl BenchCase {
         let sort = make_sort_exprs(schema.as_ref());
 
         let source = MemorySourceConfig::try_new_exec(partitions, schema, None).unwrap();
-        let exec = SortExec::new(sort, source).with_preserve_partitioning(true);
+        let exec = SortExec::new(sort, source, task_ctx.session_config().get_extension())
+            .with_preserve_partitioning(true);
         let plan = Arc::new(CoalescePartitionsExec::new(Arc::new(exec)));
 
         Self {

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -64,6 +64,7 @@ use datafusion_optimizer::{
     Analyzer, AnalyzerRule, Optimizer, OptimizerConfig, OptimizerRule,
 };
 use datafusion_physical_expr::create_physical_expr;
+use datafusion_physical_expr::expressions::DynamicFiltersRegistry;
 use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
 use datafusion_physical_optimizer::optimizer::PhysicalOptimizer;
 use datafusion_physical_optimizer::PhysicalOptimizerRule;
@@ -1375,7 +1376,9 @@ impl SessionStateBuilder {
             physical_optimizer_rules,
         } = self;
 
-        let config = config.unwrap_or_default();
+        let config = config
+            .unwrap_or_default()
+            .with_extension(Arc::new(DynamicFiltersRegistry::default()));
         let runtime_env = runtime_env.unwrap_or_else(|| Arc::new(RuntimeEnv::default()));
 
         let mut state = SessionState {

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -930,7 +930,12 @@ impl DefaultPhysicalPlanner {
                         "SortExec requires at least one sort expression"
                     );
                 };
-                let new_sort = SortExec::new(ordering, physical_input).with_fetch(*fetch);
+                let new_sort = SortExec::new(
+                    ordering,
+                    physical_input,
+                    session_state.config().get_extension(),
+                )
+                .with_fetch(*fetch);
                 Arc::new(new_sort)
             }
             LogicalPlan::Subquery(_) => todo!(),

--- a/datafusion/core/tests/execution/coop.rs
+++ b/datafusion/core/tests/execution/coop.rs
@@ -330,7 +330,11 @@ async fn sort_yields(
     );
 
     let lex_ordering = LexOrdering::new(vec![sort_expr]).unwrap();
-    let sort_exec = Arc::new(SortExec::new(lex_ordering, inf.clone()));
+    let sort_exec = Arc::new(SortExec::new(
+        lex_ordering,
+        inf.clone(),
+        session_ctx.task_ctx().session_config().get_extension(),
+    ));
 
     query_yields(sort_exec, session_ctx.task_ctx()).await
 }

--- a/datafusion/core/tests/fuzz_cases/spilling_fuzz_in_memory_constrained_env.rs
+++ b/datafusion/core/tests/fuzz_cases/spilling_fuzz_in_memory_constrained_env.rs
@@ -306,6 +306,7 @@ async fn run_sort_test_with_limited_memory(
         }])
         .unwrap(),
         plan,
+        args.task_ctx.session_config().get_extension(),
     ));
 
     let result = sort_exec.execute(0, Arc::clone(&args.task_ctx))?;

--- a/datafusion/core/tests/fuzz_cases/window_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/window_fuzz.rs
@@ -646,7 +646,11 @@ async fn run_window_test(
     // For WindowAggExec  to produce correct result it need table to be ordered by b,a. Hence add a sort.
     if is_linear {
         if let Some(ordering) = LexOrdering::new(sort_keys) {
-            exec1 = Arc::new(SortExec::new(ordering, exec1)) as _;
+            exec1 = Arc::new(SortExec::new(
+                ordering,
+                exec1,
+                ctx.task_ctx().session_config().get_extension(),
+            )) as _;
         }
     }
 

--- a/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
@@ -349,7 +349,9 @@ fn ensure_distribution_helper(
     config.optimizer.repartition_file_scans = false;
     config.optimizer.repartition_file_min_size = 1024;
     config.optimizer.prefer_existing_sort = prefer_existing_sort;
-    ensure_distribution(distribution_context, &config).map(|item| item.data.plan)
+    let session_config = SessionConfig::from(config);
+
+    ensure_distribution(distribution_context, &session_config).map(|item| item.data.plan)
 }
 
 /// Test whether plan matches with expected plan
@@ -503,10 +505,7 @@ impl TestConfig {
             // Then run ensure_distribution rule
             DistributionContext::new_default(adjusted)
                 .transform_up(|distribution_context| {
-                    ensure_distribution(
-                        distribution_context,
-                        self.session_config.options(),
-                    )
+                    ensure_distribution(distribution_context, &self.session_config)
                 })
                 .data()
                 .and_then(check_integrity)?;

--- a/datafusion/core/tests/physical_optimizer/partition_statistics.rs
+++ b/datafusion/core/tests/physical_optimizer/partition_statistics.rs
@@ -271,7 +271,7 @@ mod test {
             Arc::new(Column::new("id", 0)),
             SortOptions::new(false, false),
         )];
-        let sort = SortExec::new(ordering.clone().into(), scan_1);
+        let sort = SortExec::new(ordering.clone().into(), scan_1, None);
         let sort_exec: Arc<dyn ExecutionPlan> = Arc::new(sort);
         let statistics = (0..sort_exec.output_partitioning().partition_count())
             .map(|idx| sort_exec.partition_statistics(Some(idx)))
@@ -288,7 +288,7 @@ mod test {
         let scan_2 = create_scan_exec_with_statistics(None, Some(2)).await;
         // Add sort execution plan
         let sort_exec: Arc<dyn ExecutionPlan> = Arc::new(
-            SortExec::new(ordering.into(), scan_2).with_preserve_partitioning(true),
+            SortExec::new(ordering.into(), scan_2, None).with_preserve_partitioning(true),
         );
         let expected_statistic_partition_1 =
             create_partition_statistics(2, 110, 3, 4, true);

--- a/datafusion/core/tests/physical_optimizer/projection_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/projection_pushdown.rs
@@ -1439,6 +1439,7 @@ fn test_sort_after_projection() -> Result<()> {
         ]
         .into(),
         csv,
+        None,
     );
     let projection: Arc<dyn ExecutionPlan> = Arc::new(ProjectionExec::try_new(
         vec![

--- a/datafusion/core/tests/physical_optimizer/test_utils.rs
+++ b/datafusion/core/tests/physical_optimizer/test_utils.rs
@@ -379,7 +379,7 @@ pub fn sort_exec_with_preserve_partitioning(
     ordering: LexOrdering,
     input: Arc<dyn ExecutionPlan>,
 ) -> Arc<dyn ExecutionPlan> {
-    Arc::new(SortExec::new(ordering, input).with_preserve_partitioning(true))
+    Arc::new(SortExec::new(ordering, input, None).with_preserve_partitioning(true))
 }
 
 pub fn sort_exec_with_fetch(
@@ -387,7 +387,7 @@ pub fn sort_exec_with_fetch(
     fetch: Option<usize>,
     input: Arc<dyn ExecutionPlan>,
 ) -> Arc<dyn ExecutionPlan> {
-    Arc::new(SortExec::new(ordering, input).with_fetch(fetch))
+    Arc::new(SortExec::new(ordering, input, None).with_fetch(fetch))
 }
 
 pub fn projection_exec(

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -812,6 +812,8 @@ mod test {
         Arc::new(DynamicFilterPhysicalExpr::new(
             expr.children().into_iter().map(Arc::clone).collect(),
             expr,
+            Default::default(),
+            None,
         ))
     }
 

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -40,6 +40,7 @@ name = "datafusion_physical_expr"
 [dependencies]
 ahash = { workspace = true }
 arrow = { workspace = true }
+dashmap = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
 datafusion-expr-common = { workspace = true }
@@ -52,6 +53,7 @@ itertools = { workspace = true, features = ["use_std"] }
 parking_lot = { workspace = true }
 paste = "^1.0"
 petgraph = "0.8.3"
+uuid = { version = "1.18", features = ["v4"] }
 
 [dev-dependencies]
 arrow = { workspace = true, features = ["test_utils"] }

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -45,7 +45,7 @@ pub use cast::{cast, CastExpr};
 pub use cast_column::CastColumnExpr;
 pub use column::{col, with_new_schema, Column};
 pub use datafusion_expr::utils::format_state_name;
-pub use dynamic_filters::DynamicFilterPhysicalExpr;
+pub use dynamic_filters::{DynamicFilterPhysicalExpr, DynamicFiltersRegistry};
 pub use in_list::{in_list, InListExpr};
 pub use is_not_null::{is_not_null, IsNotNullExpr};
 pub use is_null::{is_null, IsNullExpr};

--- a/datafusion/physical-expr/src/lib.rs
+++ b/datafusion/physical-expr/src/lib.rs
@@ -67,6 +67,7 @@ pub use datafusion_physical_expr_common::sort_expr::{
     PhysicalSortRequirement,
 };
 
+pub use expressions::DynamicFiltersRegistry;
 pub use planner::{create_physical_expr, create_physical_exprs};
 pub use scalar_function::ScalarFunctionExpr;
 pub use simplifier::PhysicalExprSimplifier;

--- a/datafusion/physical-plan/src/sorts/partial_sort.rs
+++ b/datafusion/physical-plan/src/sorts/partial_sort.rs
@@ -765,6 +765,7 @@ mod tests {
         let sort_exec = Arc::new(SortExec::new(
             partial_sort_exec.expr.clone(),
             Arc::clone(&partial_sort_exec.input),
+            task_ctx.session_config().get_extension(),
         ));
         let result = collect(Arc::new(partial_sort_exec), Arc::clone(&task_ctx)).await?;
         assert_eq!(
@@ -828,6 +829,7 @@ mod tests {
                 SortExec::new(
                     partial_sort_exec.expr.clone(),
                     Arc::clone(&partial_sort_exec.input),
+                    task_ctx.session_config().get_extension(),
                 )
                 .with_fetch(fetch_size),
             );

--- a/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
+++ b/datafusion/physical-plan/src/sorts/sort_preserving_merge.rs
@@ -759,8 +759,14 @@ mod tests {
         sort: LexOrdering,
         context: Arc<TaskContext>,
     ) -> RecordBatch {
-        let sort_exec =
-            Arc::new(SortExec::new(sort.clone(), input).with_preserve_partitioning(true));
+        let sort_exec = Arc::new(
+            SortExec::new(
+                sort.clone(),
+                input,
+                context.session_config().get_extension(),
+            )
+            .with_preserve_partitioning(true),
+        );
         sorted_merge(sort_exec, sort, context).await
     }
 
@@ -770,7 +776,11 @@ mod tests {
         context: Arc<TaskContext>,
     ) -> RecordBatch {
         let merge = Arc::new(CoalescePartitionsExec::new(src));
-        let sort_exec = Arc::new(SortExec::new(sort, merge));
+        let sort_exec = Arc::new(SortExec::new(
+            sort,
+            merge,
+            context.session_config().get_extension(),
+        ));
         let mut result = collect(sort_exec, context).await.unwrap();
         assert_eq!(result.len(), 1);
         result.remove(0)

--- a/datafusion/physical-plan/src/topk/mod.rs
+++ b/datafusion/physical-plan/src/topk/mod.rs
@@ -1142,7 +1142,12 @@ mod tests {
             runtime,
             &metrics,
             Arc::new(RwLock::new(TopKDynamicFilters::new(Arc::new(
-                DynamicFilterPhysicalExpr::new(vec![], lit(true)),
+                DynamicFilterPhysicalExpr::new(
+                    vec![],
+                    lit(true),
+                    Default::default(),
+                    None,
+                ),
             )))),
         )?;
 

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -71,6 +71,7 @@ pbjson = { workspace = true, optional = true }
 prost = { workspace = true }
 serde = { version = "1.0", optional = true }
 serde_json = { workspace = true, optional = true }
+uuid = { version = "1.18", features = ["v4"] }
 
 [dev-dependencies]
 datafusion = { workspace = true, default-features = false, features = [

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -864,6 +864,8 @@ message PhysicalExprNode {
     PhysicalExtensionExprNode extension = 19;
 
     UnknownColumn unknown_column = 20;
+
+    PhysicalDynamicFilterNode dynamic_filter = 21;
   }
 }
 
@@ -938,6 +940,12 @@ message PhysicalLikeExprNode {
   bool case_insensitive = 2;
   PhysicalExprNode expr = 3;
   PhysicalExprNode pattern = 4;
+}
+
+message PhysicalDynamicFilterNode {
+  repeated PhysicalExprNode children = 1;
+  PhysicalExprNode inner = 2;
+  bytes id = 3;
 }
 
 message PhysicalSortExprNode {
@@ -1225,6 +1233,7 @@ message SortExecNode {
   // Maximum number of highest/lowest rows to fetch; negative means no limit
   int64 fetch = 3;
   bool preserve_partitioning = 4;
+  PhysicalDynamicFilterNode filter = 5;
 }
 
 message SortPreservingMergeExecNode {

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -15703,6 +15703,135 @@ impl<'de> serde::Deserialize<'de> for PhysicalDateTimeIntervalExprNode {
         deserializer.deserialize_struct("datafusion.PhysicalDateTimeIntervalExprNode", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for PhysicalDynamicFilterNode {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.children.is_empty() {
+            len += 1;
+        }
+        if self.inner.is_some() {
+            len += 1;
+        }
+        if !self.id.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("datafusion.PhysicalDynamicFilterNode", len)?;
+        if !self.children.is_empty() {
+            struct_ser.serialize_field("children", &self.children)?;
+        }
+        if let Some(v) = self.inner.as_ref() {
+            struct_ser.serialize_field("inner", v)?;
+        }
+        if !self.id.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            #[allow(clippy::needless_borrows_for_generic_args)]
+            struct_ser.serialize_field("id", pbjson::private::base64::encode(&self.id).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for PhysicalDynamicFilterNode {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "children",
+            "inner",
+            "id",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Children,
+            Inner,
+            Id,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "children" => Ok(GeneratedField::Children),
+                            "inner" => Ok(GeneratedField::Inner),
+                            "id" => Ok(GeneratedField::Id),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = PhysicalDynamicFilterNode;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct datafusion.PhysicalDynamicFilterNode")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PhysicalDynamicFilterNode, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut children__ = None;
+                let mut inner__ = None;
+                let mut id__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Children => {
+                            if children__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("children"));
+                            }
+                            children__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Inner => {
+                            if inner__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("inner"));
+                            }
+                            inner__ = map_.next_value()?;
+                        }
+                        GeneratedField::Id => {
+                            if id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("id"));
+                            }
+                            id__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(PhysicalDynamicFilterNode {
+                    children: children__.unwrap_or_default(),
+                    inner: inner__,
+                    id: id__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("datafusion.PhysicalDynamicFilterNode", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for PhysicalExprNode {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -15771,6 +15900,9 @@ impl serde::Serialize for PhysicalExprNode {
                 physical_expr_node::ExprType::UnknownColumn(v) => {
                     struct_ser.serialize_field("unknownColumn", v)?;
                 }
+                physical_expr_node::ExprType::DynamicFilter(v) => {
+                    struct_ser.serialize_field("dynamicFilter", v)?;
+                }
             }
         }
         struct_ser.end()
@@ -15813,6 +15945,8 @@ impl<'de> serde::Deserialize<'de> for PhysicalExprNode {
             "extension",
             "unknown_column",
             "unknownColumn",
+            "dynamic_filter",
+            "dynamicFilter",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -15835,6 +15969,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalExprNode {
             LikeExpr,
             Extension,
             UnknownColumn,
+            DynamicFilter,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -15874,6 +16009,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalExprNode {
                             "likeExpr" | "like_expr" => Ok(GeneratedField::LikeExpr),
                             "extension" => Ok(GeneratedField::Extension),
                             "unknownColumn" | "unknown_column" => Ok(GeneratedField::UnknownColumn),
+                            "dynamicFilter" | "dynamic_filter" => Ok(GeneratedField::DynamicFilter),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -16020,6 +16156,13 @@ impl<'de> serde::Deserialize<'de> for PhysicalExprNode {
                                 return Err(serde::de::Error::duplicate_field("unknownColumn"));
                             }
                             expr_type__ = map_.next_value::<::std::option::Option<_>>()?.map(physical_expr_node::ExprType::UnknownColumn)
+;
+                        }
+                        GeneratedField::DynamicFilter => {
+                            if expr_type__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("dynamicFilter"));
+                            }
+                            expr_type__ = map_.next_value::<::std::option::Option<_>>()?.map(physical_expr_node::ExprType::DynamicFilter)
 ;
                         }
                     }
@@ -20531,6 +20674,9 @@ impl serde::Serialize for SortExecNode {
         if self.preserve_partitioning {
             len += 1;
         }
+        if self.filter.is_some() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("datafusion.SortExecNode", len)?;
         if let Some(v) = self.input.as_ref() {
             struct_ser.serialize_field("input", v)?;
@@ -20545,6 +20691,9 @@ impl serde::Serialize for SortExecNode {
         }
         if self.preserve_partitioning {
             struct_ser.serialize_field("preservePartitioning", &self.preserve_partitioning)?;
+        }
+        if let Some(v) = self.filter.as_ref() {
+            struct_ser.serialize_field("filter", v)?;
         }
         struct_ser.end()
     }
@@ -20561,6 +20710,7 @@ impl<'de> serde::Deserialize<'de> for SortExecNode {
             "fetch",
             "preserve_partitioning",
             "preservePartitioning",
+            "filter",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -20569,6 +20719,7 @@ impl<'de> serde::Deserialize<'de> for SortExecNode {
             Expr,
             Fetch,
             PreservePartitioning,
+            Filter,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -20594,6 +20745,7 @@ impl<'de> serde::Deserialize<'de> for SortExecNode {
                             "expr" => Ok(GeneratedField::Expr),
                             "fetch" => Ok(GeneratedField::Fetch),
                             "preservePartitioning" | "preserve_partitioning" => Ok(GeneratedField::PreservePartitioning),
+                            "filter" => Ok(GeneratedField::Filter),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -20617,6 +20769,7 @@ impl<'de> serde::Deserialize<'de> for SortExecNode {
                 let mut expr__ = None;
                 let mut fetch__ = None;
                 let mut preserve_partitioning__ = None;
+                let mut filter__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Input => {
@@ -20645,6 +20798,12 @@ impl<'de> serde::Deserialize<'de> for SortExecNode {
                             }
                             preserve_partitioning__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::Filter => {
+                            if filter__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("filter"));
+                            }
+                            filter__ = map_.next_value()?;
+                        }
                     }
                 }
                 Ok(SortExecNode {
@@ -20652,6 +20811,7 @@ impl<'de> serde::Deserialize<'de> for SortExecNode {
                     expr: expr__.unwrap_or_default(),
                     fetch: fetch__.unwrap_or_default(),
                     preserve_partitioning: preserve_partitioning__.unwrap_or_default(),
+                    filter: filter__,
                 })
             }
         }

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -1261,7 +1261,7 @@ pub struct PhysicalExtensionNode {
 pub struct PhysicalExprNode {
     #[prost(
         oneof = "physical_expr_node::ExprType",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 18, 19, 20"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 18, 19, 20, 21"
     )]
     pub expr_type: ::core::option::Option<physical_expr_node::ExprType>,
 }
@@ -1312,6 +1312,8 @@ pub mod physical_expr_node {
         Extension(super::PhysicalExtensionExprNode),
         #[prost(message, tag = "20")]
         UnknownColumn(super::UnknownColumn),
+        #[prost(message, tag = "21")]
+        DynamicFilter(::prost::alloc::boxed::Box<super::PhysicalDynamicFilterNode>),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1440,6 +1442,15 @@ pub struct PhysicalLikeExprNode {
     pub expr: ::core::option::Option<::prost::alloc::boxed::Box<PhysicalExprNode>>,
     #[prost(message, optional, boxed, tag = "4")]
     pub pattern: ::core::option::Option<::prost::alloc::boxed::Box<PhysicalExprNode>>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PhysicalDynamicFilterNode {
+    #[prost(message, repeated, tag = "1")]
+    pub children: ::prost::alloc::vec::Vec<PhysicalExprNode>,
+    #[prost(message, optional, boxed, tag = "2")]
+    pub inner: ::core::option::Option<::prost::alloc::boxed::Box<PhysicalExprNode>>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub id: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PhysicalSortExprNode {
@@ -1840,6 +1851,8 @@ pub struct SortExecNode {
     pub fetch: i64,
     #[prost(bool, tag = "4")]
     pub preserve_partitioning: bool,
+    #[prost(message, optional, tag = "5")]
+    pub filter: ::core::option::Option<PhysicalDynamicFilterNode>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SortPreservingMergeExecNode {


### PR DESCRIPTION
This PR need the following other PRs to be merged first:
- https://github.com/apache/datafusion/pull/18168

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- No issue

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently, the producer and consumer ends of a `DynamicFilterPhysicalExpr` depend on their `inner` pointers to be the same in order to properly communicate updates on the inner filter values:

```dart
SortExec(DynamicFilterPhysicalExpr(Arc<RwLock<Inner>>)) // <- this Arc pointer...
  SomeOtherExec
    DataSourceExec(DynamicFilterPhysicalExpr(Arc<RwLock<Inner>>)) // <- ...must be the same as this one
```

However, under certain situations, both producer and consumer parts of `DynamicFilterPhysicalExpr` will not necessary share the same Arc pointer, like when the `DynamicFilterPhysicalExpr` gets serialized from protobuf and then deserialized.

---

This PR proposes an alternative way of storing the `Arc<RwLock<Inner>>` inner values of a dynamic filters: a `DynamicFilterRegistry` structure that lives globally to a DataFusion session, and that different instances of a `DynamicFilterPhysicalExpr` in a plan can access through the `SessionConfig` using a unique identifier.

```dart
SessionState(
  SessionConfig(
    DynamicFilterRegistry(HashMap<Uuid, Inner>)
  )
)

SortExec(DynamicFilterPhysicalExpr(Uuid)) // <- this pushes updates to session_config.dynamic_registry[Uuid]
  SomeOtherExec
    DataSourceExec(DynamicFilterPhysicalExpr(Uuid)) // <- this reads updates from session_config.dynamic_registry[Uuid]
```

Allows serializing/deserializing dynamic filters from and to protobuf, while keeping the producer and consumer part of the dynamic filter connected.

Having a registry of dynamic filter values global to a session could allow us to subscribe to changes there in the future, so that they can be streamed and synced over the wire in a distributed query. A potential evolution for allowing this could be making `DynamicFilterRegistry` a trait, very roughly something like this:

```rust
trait DynamicFilterRegistry {
    fn push_changes(&self, id: Uuid, value: Arc<dyn PhysicalExpr>);

    fn consume_changes(&self, id: Uuid) -> Arc<dyn PhysicalExpr):
}
```

That distributed systems could implement themselves.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Introduce a new `DynamicFilterRegistry` structure that holds dynamic filter values.
- Store a `DynamicFilterRegistry` in the `SessionConfig` so that it's shared across any plan in the same session.
- Adds protobuf serialization/deserialization support for dynamic filters
- Adds a new test that checks that roundtrips dynamic filter serialization

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

yes, by existing tests and a new test.

## Are there any user-facing changes?

Users of the `datafusion-proto` package can now serialize/deserialize dynamic filters

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
